### PR TITLE
Fix crouching, pickups, boss issues, text, add breakable blocks

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -186,8 +186,12 @@ class MenuScene extends Phaser.Scene {
             fontFamily: FONT, fontSize: '9px', color: '#7a8a7a'
         }).setOrigin(0.5);
 
-        this.add.text(W/2, 210, 'ARROWS: move/jump  DOWN: crouch  SPACE: shoot', {
+        this.add.text(W/2, 210, 'ARROWS: move/jump  DOWN/CTRL: crouch  SPACE: shoot', {
             fontFamily: FONT, fontSize: '8px', color: '#6a7a6a'
+        }).setOrigin(0.5);
+
+        this.add.text(W/2, 230, 'Shoot ? BLOCKS for power-ups!', {
+            fontFamily: FONT, fontSize: '7px', color: '#ddaa00'
         }).setOrigin(0.5);
 
         // preview sprites
@@ -263,6 +267,14 @@ class GameScene extends Phaser.Scene {
         this.facingRight = true;
         this.overlayShown = false;
 
+        // Power-up state
+        this.activePowerups = {};
+        this.powerupTimers = {};
+        this.shieldActive = false;
+
+        // Breakable blocks
+        this.breakableBlocks = [];
+
         // Boss projectiles array (manually managed)
         this.bossProjectiles = [];
         // Damage zones (ground crack, fire trail, etc.)
@@ -317,9 +329,9 @@ class GameScene extends Phaser.Scene {
         this.platformGraphics = this.add.graphics();
         this.drawPlatforms();
 
-        // ---- Goal post ----
+        // ---- Goal post (hidden until boss is defeated) ----
         this.goalGraphics = this.add.graphics();
-        this.drawGoalPost();
+        this.goalGraphics.setVisible(false);
 
         // ---- Player ----
         this.createPlayer();
@@ -334,6 +346,11 @@ class GameScene extends Phaser.Scene {
 
         // ---- Pickups ----
         this.pickups = this.physics.add.group();
+
+        // ---- Breakable blocks graphics ----
+        this.blockGraphics = this.add.graphics();
+        this.generateBreakableBlocks(levelIndex);
+        this.drawBreakableBlocks();
 
         // ---- Boss reference ----
         this.boss = null;
@@ -352,6 +369,8 @@ class GameScene extends Phaser.Scene {
         this.physics.add.collider(this.player, this.platforms);
         this.physics.add.collider(this.enemyGroup, groundBody);
         this.physics.add.collider(this.enemyGroup, this.platforms);
+        this.physics.add.collider(this.pickups, groundBody);
+        this.physics.add.collider(this.pickups, this.platforms);
         this.physics.add.overlap(this.carrots, this.enemyGroup, this.carrotHitEnemy, null, this);
         this.physics.add.overlap(this.player, this.pickups, this.collectPickup, null, this);
         this.physics.add.overlap(this.player, this.enemyGroup, this.playerTouchEnemy, null, this);
@@ -365,6 +384,7 @@ class GameScene extends Phaser.Scene {
         // ---- Input ----
         this.cursors = this.input.keyboard.createCursorKeys();
         this.spaceKey = this.input.keyboard.addKey(Phaser.Input.Keyboard.KeyCodes.SPACE);
+        this.ctrlKey = this.input.keyboard.addKey(Phaser.Input.Keyboard.KeyCodes.CTRL);
 
         // Camera follow
         this.cameras.main.startFollow(this.player, false, 0.1, 0.1);
@@ -804,6 +824,7 @@ class GameScene extends Phaser.Scene {
         this.updatePlayer(time, delta);
         this.updateEnemies(time, delta);
         this.updateCarrots();
+        this.updateBreakableBlocks();
         this.updateBoss(time, delta);
         this.updateBossProjectiles(delta);
         this.updateDamageZones(delta);
@@ -824,30 +845,57 @@ class GameScene extends Phaser.Scene {
         let onGround = p.body.blocked.down;
         let moving = false;
         this.isCrouching = false;
+        let shootCooldown = this.activePowerups.rapid_fire ? SHOOT_COOLDOWN * 0.4 : SHOOT_COOLDOWN;
 
         // Reset velocity
         p.setVelocityX(0);
 
-        // Crouch
-        if (this.cursors.down.isDown && onGround) {
+        // Crouch (DOWN arrow or CTRL key while on ground)
+        let crouchInput = (this.cursors.down.isDown || this.ctrlKey.isDown) && onGround;
+        if (crouchInput) {
             this.isCrouching = true;
             p.setFrame('FARMER_CROUCH');
             p.body.setSize(13, 10);
             p.body.setOffset(1.5, 6);
-            return; // cannot move or shoot while crouching
+            // Allow slow movement while crouching
+            let crouchSpeed = (this.activePowerups.speed_boost ? MOVE_SPEED * 1.5 : MOVE_SPEED) * 0.4;
+            if (this.cursors.left.isDown) {
+                p.setVelocityX(-crouchSpeed);
+                this.facingRight = false;
+                p.setFlipX(true);
+                moving = true;
+            } else if (this.cursors.right.isDown) {
+                p.setVelocityX(crouchSpeed);
+                this.facingRight = true;
+                p.setFlipX(false);
+                moving = true;
+            }
+            // Allow shooting while crouching
+            if (this.spaceKey.isDown && this.ammo > 0) {
+                if (time > this.shootTimer) {
+                    this.shootTimer = time + shootCooldown;
+                    this.ammo--;
+                    this.shootCarrot();
+                }
+            }
+            // Landing dust
+            if (onGround && this.wasInAir) this.spawnLandingDust(p.x, p.y);
+            this.wasInAir = false;
+            return; // no jump while crouching
         } else {
             p.body.setSize(13, 16);
             p.body.setOffset(1.5, 0);
         }
 
         // Movement
+        let moveSpeed = this.activePowerups.speed_boost ? MOVE_SPEED * 1.5 : MOVE_SPEED;
         if (this.cursors.left.isDown) {
-            p.setVelocityX(-MOVE_SPEED);
+            p.setVelocityX(-moveSpeed);
             this.facingRight = false;
             p.setFlipX(true);
             moving = true;
         } else if (this.cursors.right.isDown) {
-            p.setVelocityX(MOVE_SPEED);
+            p.setVelocityX(moveSpeed);
             this.facingRight = true;
             p.setFlipX(false);
             moving = true;
@@ -881,9 +929,9 @@ class GameScene extends Phaser.Scene {
         this.wasInAir = !onGround;
 
         // Shoot
-        if (this.spaceKey.isDown && !this.isCrouching) {
+        if (this.spaceKey.isDown) {
             if (time > this.shootTimer && this.ammo > 0) {
-                this.shootTimer = time + SHOOT_COOLDOWN;
+                this.shootTimer = time + shootCooldown;
                 this.ammo--;
                 this.shootCarrot();
             }
@@ -892,19 +940,33 @@ class GameScene extends Phaser.Scene {
 
     shootCarrot() {
         let dir = this.facingRight ? 1 : -1;
+        if (this.activePowerups.spread_shot) {
+            // Fire 3 carrots in a spread
+            let angles = [-0.22, 0, 0.22];
+            for (let angle of angles) {
+                this.spawnSingleCarrot(dir, angle);
+            }
+        } else {
+            this.spawnSingleCarrot(dir, 0);
+        }
+    }
+
+    spawnSingleCarrot(dir, angle) {
         let cx = this.player.x + dir * 30;
         let cy = this.player.y - SPRITE_SIZE / 2;
+        let isBig = this.activePowerups.big_carrot;
+        let scale = isBig ? S * 1.6 : S;
 
         let carrot = this.physics.add.sprite(cx, cy, 'sprites', 'CARROT_SPRITE');
-        carrot.setScale(S);
+        carrot.setScale(scale);
         carrot.setDepth(9);
-        carrot.setFlipX(!this.facingRight);
+        carrot.setFlipX(dir < 0);
+        carrot._isBig = isBig || false;
         this.carrots.add(carrot);
-        // Set physics AFTER adding to group so group defaults don't override
         carrot.body.allowGravity = false;
-        carrot.setVelocityX(dir * CARROT_SPEED);
+        carrot.setVelocityX(dir * CARROT_SPEED * Math.cos(angle));
+        carrot.setVelocityY(Math.sin(angle) * CARROT_SPEED);
 
-        // Destroy if off screen
         this.time.delayedCall(2000, () => {
             if (carrot && carrot.active) carrot.destroy();
         });
@@ -964,34 +1026,37 @@ class GameScene extends Phaser.Scene {
         switch (ed.type) {
             case 'bunny': {
                 let states = ['IDLE', 'HOP_TOWARD', 'HOP_AWAY'];
-                let weights = [70, 20, 10];
-                if (dist < 100) weights = [20, 10, 70];
+                // More aggressive: less idle, more active pursuit
+                let weights = [25, 50, 25];
+                if (dist < 120) weights = [15, 20, 65]; // retreat when close
+                if (dist > 400) weights = [10, 75, 15]; // charge when far
                 ed.state = states[weightedPick(weights)];
-                ed.stateTimer = 120 + Math.floor(Math.random() * 60);
+                ed.stateTimer = 60 + Math.floor(Math.random() * 60);
                 break;
             }
             case 'tortoise': {
                 let states = ['PATROL', 'TRACK', 'STOP_AND_GO'];
-                let weights = [40, 30, 30];
-                if (dist < 280) weights = [15, 55, 30];
+                let weights = [25, 45, 30]; // more tracking
+                if (dist < 280) weights = [10, 65, 25]; // aggressively track when near
                 ed.state = states[weightedPick(weights)];
-                ed.stateTimer = 120 + Math.floor(Math.random() * 60);
+                ed.stateTimer = 90 + Math.floor(Math.random() * 60);
                 break;
             }
             case 'fox': {
                 let states = ['PATROL', 'STALK', 'FEINT', 'ZIGZAG_CHARGE', 'LEAP'];
-                let weights = [30, 20, 15, 20, 15];
-                if (dist < 200) weights = [10, 15, 20, 30, 25];
+                let weights = [15, 20, 20, 25, 20]; // more aggressive mix
+                if (dist < 200) weights = [5, 10, 25, 35, 25]; // very aggressive when near
+                if (dist > 350) weights = [10, 30, 15, 25, 20];
                 ed.state = states[weightedPick(weights)];
-                ed.stateTimer = 100 + Math.floor(Math.random() * 50);
-                ed.chargeSpeedMult = 0.7 + Math.random() * 0.6;
+                ed.stateTimer = 70 + Math.floor(Math.random() * 50);
+                ed.chargeSpeedMult = 0.8 + Math.random() * 0.7;
                 break;
             }
             case 'crow': {
                 let states = ['SINE_PATROL', 'SWOOP_DIVE', 'CIRCLE'];
-                let weights = [40, 30, 30];
+                let weights = [25, 45, 30]; // more swooping
                 ed.state = states[weightedPick(weights)];
-                ed.stateTimer = 150 + Math.floor(Math.random() * 100);
+                ed.stateTimer = 100 + Math.floor(Math.random() * 80);
                 ed.swooping = false;
                 ed.circleAngle = Math.random() * Math.PI * 2;
                 break;
@@ -1276,6 +1341,12 @@ class GameScene extends Phaser.Scene {
 
     takeDamage() {
         if (this.invincibleTimer > 0) return;
+        if (this.shieldActive) {
+            this.shieldActive = false;
+            this.invincibleTimer = 1500;
+            this.spawnScorePopup(this.player.x, this.player.y - SPRITE_SIZE, 'BLOCKED!');
+            return;
+        }
         this.playerHP--;
         this.invincibleTimer = 1500; // 1.5 seconds (90 frames at 60fps)
 
@@ -1332,25 +1403,27 @@ class GameScene extends Phaser.Scene {
         let pickup;
 
         if (isHealth) {
-            pickup = this.physics.add.sprite(x, y, 'sprites', 'HEART');
+            pickup = this.physics.add.sprite(x, y - 20, 'sprites', 'HEART');
             pickup.setScale(3);
             pickup._pickupType = 'health';
             pickup._amount = 1;
         } else {
-            pickup = this.physics.add.sprite(x, y, 'sprites', 'CARROT_SPRITE');
+            pickup = this.physics.add.sprite(x, y - 20, 'sprites', 'CARROT_SPRITE');
             pickup.setScale(2);
             pickup._pickupType = 'ammo';
             pickup._amount = ed.ammoDrop;
         }
 
-        pickup.body.allowGravity = false;
+        // Let gravity pull it down onto the platform/ground naturally
+        pickup.body.allowGravity = true;
+        pickup.body.setGravityY(200);
+        pickup.setBounce(0.2);
         pickup.setDepth(7);
         pickup._bobPhase = Math.random() * Math.PI * 2;
-        pickup._baseY = y;
         this.pickups.add(pickup);
 
-        // Auto-destroy after 8 seconds
-        this.time.delayedCall(8000, () => {
+        // Auto-destroy after 12 seconds
+        this.time.delayedCall(12000, () => {
             if (pickup && pickup.active) pickup.destroy();
         });
     }
@@ -1358,8 +1431,10 @@ class GameScene extends Phaser.Scene {
     updatePickups() {
         this.pickups.getChildren().forEach(p => {
             if (!p.active) return;
-            p._bobPhase += 0.05;
-            p.y = p._baseY + Math.sin(p._bobPhase) * 5;
+            // Gentle pulse tint to make pickups visible
+            p._bobPhase += 0.08;
+            let alpha = 0.7 + Math.sin(p._bobPhase) * 0.3;
+            p.setAlpha(alpha);
         });
     }
 
@@ -1369,11 +1444,30 @@ class GameScene extends Phaser.Scene {
                 this.playerHP++;
                 this.spawnScorePopup(pickup.x, pickup.y - 20, '+1 HP');
             }
+        } else if (pickup._pickupType === 'powerup') {
+            this.activatePowerup(pickup._powerupType);
         } else {
             this.ammo = Math.min(this.maxAmmo, this.ammo + pickup._amount);
             this.spawnScorePopup(pickup.x, pickup.y - 20, '+' + pickup._amount);
         }
         pickup.destroy();
+    }
+
+    activatePowerup(type) {
+        let labels = {
+            spread_shot: 'SPREAD SHOT!', rapid_fire: 'RAPID FIRE!',
+            big_carrot: 'BIG CARROTS!', shield: 'SHIELD!', speed_boost: 'SPEED BOOST!'
+        };
+        if (type === 'shield') {
+            this.shieldActive = true;
+        } else {
+            this.activePowerups[type] = true;
+            if (this.powerupTimers[type]) this.powerupTimers[type].remove();
+            this.powerupTimers[type] = this.time.delayedCall(10000, () => {
+                delete this.activePowerups[type];
+            });
+        }
+        this.spawnScorePopup(this.player.x, this.player.y - SPRITE_SIZE, labels[type] || type);
     }
 
     // --------------------------------------------------------
@@ -1530,6 +1624,11 @@ class GameScene extends Phaser.Scene {
 
         this.boss.sprite.destroy();
         this.boss = null;
+
+        // Reveal the goal post now that boss is defeated
+        this.drawGoalPost();
+        this.goalGraphics.setVisible(true);
+        this.spawnScorePopup(this.GOAL_X, GROUND_Y - 60, 'REACH THE GOAL!');
     }
 
     // --------------------------------------------------------
@@ -1587,6 +1686,9 @@ class GameScene extends Phaser.Scene {
 
         // Clamp position
         s.x = Math.max(b.minX, Math.min(b.maxX, s.x));
+        if (b.isFlying) {
+            s.y = Math.max(40, Math.min(GROUND_Y - 20, s.y));
+        }
 
         // Update shield rocks
         if (b.shieldRocks && b.shieldRocks.length > 0) {
@@ -1613,8 +1715,8 @@ class GameScene extends Phaser.Scene {
 
         switch (b.type) {
             case 'bunny_king':
-                attacks = ['spread', 'homing', 'ground_pound', 'summon', 'hop'];
-                weights = b.enraged ? [25, 20, 25, 20, 10] : [30, 15, 20, 10, 25];
+                attacks = ['spread', 'homing', 'ground_pound', 'summon', 'hop', 'spiral'];
+                weights = b.enraged ? [20, 15, 20, 15, 10, 20] : [25, 15, 15, 10, 20, 15];
                 break;
             case 'golem':
                 attacks = ['walk_slam', 'rock_rain', 'charge', 'ground_crack', 'rock_shield', 'rock_drop'];
@@ -1633,8 +1735,8 @@ class GameScene extends Phaser.Scene {
                 weights = b.enraged ? [25, 25, 25, 25] : [30, 20, 25, 25];
                 break;
             case 'ruin_knight':
-                attacks = ['sword_slash', 'shield_charge', 'summon_wolves', 'teleport_strike', 'magic_orb'];
-                weights = b.enraged ? [20, 20, 15, 25, 20] : [25, 20, 15, 20, 20];
+                attacks = ['sword_slash', 'shield_charge', 'summon_wolves', 'teleport_strike', 'magic_orb', 'spiral'];
+                weights = b.enraged ? [15, 15, 12, 20, 18, 20] : [20, 18, 12, 18, 17, 15];
                 break;
             default: return;
         }
@@ -1668,6 +1770,7 @@ class GameScene extends Phaser.Scene {
                     case 'ground_pound': b.startupFrames = 40; b.activeFrames = 60; b.recoveryFrames = e ? 40 : 60; break;
                     case 'summon': b.startupFrames = 20; b.activeFrames = 10; b.recoveryFrames = e ? 80 : 120; break;
                     case 'hop': b.startupFrames = 10; b.activeFrames = 30; b.recoveryFrames = e ? 40 : 60; break;
+                    case 'spiral': b.startupFrames = 15; b.activeFrames = 50; b.recoveryFrames = e ? 55 : 85; break;
                 }
                 break;
             case 'golem':
@@ -1713,6 +1816,7 @@ class GameScene extends Phaser.Scene {
                     case 'summon_wolves': b.startupFrames = 25; b.activeFrames = 10; b.recoveryFrames = e ? 70 : 100; break;
                     case 'teleport_strike': b.startupFrames = 40; b.activeFrames = 20; b.recoveryFrames = e ? 40 : 60; break;
                     case 'magic_orb': b.startupFrames = 20; b.activeFrames = 15; b.recoveryFrames = e ? 50 : 70; break;
+                    case 'spiral': b.startupFrames = 20; b.activeFrames = 60; b.recoveryFrames = e ? 45 : 70; break;
                 }
                 break;
         }
@@ -1787,6 +1891,10 @@ class GameScene extends Phaser.Scene {
                 this.time.delayedCall(500, () => {
                     if (s.active) s.setVelocityY(0);
                 });
+                break;
+            }
+            case 'spiral': {
+                b._spiralAngle = 0;
                 break;
             }
         }
@@ -1908,7 +2016,7 @@ class GameScene extends Phaser.Scene {
             case 'emerge_snap': {
                 b._emergeTargetX = px;
                 b.savedY = s.y;
-                s.y = H + 50; // burrow below
+                s.setAlpha(0.1); // appear to burrow (hide instead of going off-screen)
                 b._emergePhase = 'burrow';
                 break;
             }
@@ -2011,6 +2119,10 @@ class GameScene extends Phaser.Scene {
                 }
                 break;
             }
+            case 'spiral': {
+                b._spiralAngle = 0;
+                break;
+            }
         }
     }
 
@@ -2024,6 +2136,19 @@ class GameScene extends Phaser.Scene {
 
         switch (b.type) {
             case 'bunny_king':
+                if (name === 'spiral' && frame % 4 === 0) {
+                    b._spiralAngle = (b._spiralAngle || 0) + 0.45;
+                    let speed = b.enraged ? 280 : 220;
+                    this.spawnBossProjectile(s.x, s.y - BOSS_SIZE/2,
+                        Math.cos(b._spiralAngle) * speed, Math.sin(b._spiralAngle) * speed,
+                        'carrot', 0xffaa00);
+                    // Double spiral when enraged
+                    if (b.enraged) {
+                        this.spawnBossProjectile(s.x, s.y - BOSS_SIZE/2,
+                            Math.cos(b._spiralAngle + Math.PI) * speed, Math.sin(b._spiralAngle + Math.PI) * speed,
+                            'carrot', 0xff6600);
+                    }
+                }
                 if (name === 'ground_pound') {
                     if (b._gpPhase === 'up' && frame < 20) {
                         s.y -= 5;
@@ -2081,10 +2206,7 @@ class GameScene extends Phaser.Scene {
                         s.x += (b._emergeTargetX - s.x) * 0.1;
                         if (frame > 15) {
                             b._emergePhase = 'emerge';
-                        }
-                    } else if (b._emergePhase === 'emerge') {
-                        s.y -= 8;
-                        if (s.y <= b.savedY) {
+                            s.setAlpha(1); // pop back into view at new position
                             s.y = b.savedY;
                             b._emergePhase = 'done';
                         }
@@ -2135,6 +2257,17 @@ class GameScene extends Phaser.Scene {
                 break;
 
             case 'ruin_knight':
+                if (name === 'spiral' && frame % 3 === 0) {
+                    b._spiralAngle = (b._spiralAngle || 0) + 0.35;
+                    let speed = b.enraged ? 300 : 240;
+                    this.spawnBossProjectile(s.x, s.y - BOSS_SIZE/2,
+                        Math.cos(b._spiralAngle) * speed, Math.sin(b._spiralAngle) * speed,
+                        'orb', 0xdd66ff);
+                    this.spawnBossProjectile(s.x, s.y - BOSS_SIZE/2,
+                        Math.cos(b._spiralAngle + Math.PI * 0.5) * speed * 0.8,
+                        Math.sin(b._spiralAngle + Math.PI * 0.5) * speed * 0.8,
+                        'orb', 0xaa44ff);
+                }
                 if (name === 'shield_charge') {
                     s.x += b._chargeDir * 7;
                 }
@@ -2385,21 +2518,31 @@ class GameScene extends Phaser.Scene {
 
     showLevelCompleteOverlay() {
         let overlay = this.add.graphics();
-        overlay.fillStyle(0x000000, 0.7);
+        overlay.fillStyle(0x000000, 0.85);
         overlay.fillRect(0, 0, W, H);
         overlay.setScrollFactor(0).setDepth(200);
 
-        this.add.text(W/2, H/2 - 30, 'LEVEL ' + (this.currentLevel + 1) + ' COMPLETE!', {
-            fontFamily: FONT, fontSize: '20px', color: '#44ff44'
+        // Decorative border
+        overlay.lineStyle(4, 0x44ff44, 0.8);
+        overlay.strokeRect(40, H/2 - 80, W - 80, 160);
+        overlay.setScrollFactor(0).setDepth(200);
+
+        this.add.text(W/2, H/2 - 40, 'LEVEL ' + (this.currentLevel + 1) + ' COMPLETE!', {
+            fontFamily: FONT, fontSize: '22px', color: '#44ff44',
+            stroke: '#003300', strokeThickness: 6
         }).setOrigin(0.5).setScrollFactor(0).setDepth(201);
 
-        this.add.text(W/2, H/2 + 20, 'SCORE: ' + this.score, {
-            fontFamily: FONT, fontSize: '14px', color: '#ffd866'
+        this.add.text(W/2, H/2 + 10, 'SCORE: ' + this.score, {
+            fontFamily: FONT, fontSize: '14px', color: '#ffd866',
+            stroke: '#443300', strokeThickness: 4
         }).setOrigin(0.5).setScrollFactor(0).setDepth(201);
 
-        this.add.text(W/2, H/2 + 60, 'PRESS SPACE TO CONTINUE', {
-            fontFamily: FONT, fontSize: '10px', color: '#8ba898'
+        let cont = this.add.text(W/2, H/2 + 55, 'PRESS SPACE TO CONTINUE', {
+            fontFamily: FONT, fontSize: '11px', color: '#ffffff',
+            stroke: '#000000', strokeThickness: 4
         }).setOrigin(0.5).setScrollFactor(0).setDepth(201);
+
+        this.tweens.add({ targets: cont, alpha: 0, duration: 500, yoyo: true, repeat: -1 });
     }
 
     showVictoryOverlay() {
@@ -2421,7 +2564,8 @@ class GameScene extends Phaser.Scene {
         }).setOrigin(0.5).setScrollFactor(0).setDepth(201);
 
         this.add.text(W/2, H/2 + 80, 'PRESS SPACE FOR MENU', {
-            fontFamily: FONT, fontSize: '10px', color: '#8ba898'
+            fontFamily: FONT, fontSize: '11px', color: '#ffffff',
+            stroke: '#000000', strokeThickness: 4
         }).setOrigin(0.5).setScrollFactor(0).setDepth(201);
 
         // Celebration
@@ -2527,6 +2671,144 @@ class GameScene extends Phaser.Scene {
                 onComplete: () => p.destroy()
             });
         }
+    }
+
+    // --------------------------------------------------------
+    // Breakable blocks
+    // --------------------------------------------------------
+    generateBreakableBlocks(levelIndex) {
+        let rng = seededRandom(levelIndex * 333 + 99);
+        let blockSize = 32;
+        let count = 7 + Math.floor(rng() * 5); // 7-11 blocks per level
+
+        for (let i = 0; i < count; i++) {
+            let bx, by;
+            // Mix: some above platforms, some in open air
+            if (i < this.platformData.length && rng() > 0.4) {
+                let p = this.platformData[Math.floor(rng() * this.platformData.length)];
+                bx = p.x + rng() * Math.max(0, p.w - blockSize);
+                by = p.y - blockSize - 48 - rng() * 40;
+            } else {
+                bx = 300 + rng() * (this.levelWidth - 600);
+                by = 160 + rng() * 140;
+            }
+            bx = Math.max(100, Math.min(this.levelWidth - 200, bx));
+
+            let types = ['spread_shot', 'rapid_fire', 'big_carrot', 'shield', 'speed_boost'];
+            let powerupType = types[Math.floor(rng() * types.length)];
+
+            this.breakableBlocks.push({
+                x: bx, y: by, w: blockSize, h: blockSize,
+                active: true, powerupType: powerupType,
+                bumping: false, bumpTimer: 0
+            });
+        }
+    }
+
+    drawBreakableBlocks() {
+        let g = this.blockGraphics;
+        g.clear();
+        for (let block of this.breakableBlocks) {
+            if (!block.active) continue;
+            let x = block.x, y = block.y + (block.bumping ? -4 : 0);
+            let w = block.w, h = block.h;
+            // Shadow
+            g.fillStyle(0x443300, 0.5);
+            g.fillRect(x + 2, y + 2, w, h);
+            // Outer border
+            g.fillStyle(0x886600, 1);
+            g.fillRect(x, y, w, h);
+            // Inner fill (gold)
+            g.fillStyle(0xddaa00, 1);
+            g.fillRect(x + 2, y + 2, w - 4, h - 4);
+            // Shine
+            g.fillStyle(0xffee55, 1);
+            g.fillRect(x + 3, y + 3, w - 8, 4);
+            g.fillRect(x + 3, y + 3, 4, h - 8);
+            // Draw "?" using pixel blocks
+            let mx = Math.floor(x + w / 2), my = Math.floor(y + h / 2);
+            g.fillStyle(0x553300, 1);
+            g.fillRect(mx - 4, my - 9, 8, 2);   // top bar of ?
+            g.fillRect(mx + 2, my - 7, 2, 4);   // right side
+            g.fillRect(mx - 2, my - 3, 4, 2);   // middle curve
+            g.fillRect(mx - 2, my + 1, 4, 2);   // gap
+            g.fillRect(mx - 2, my + 4, 4, 2);   // dot
+        }
+    }
+
+    updateBreakableBlocks() {
+        let needsRedraw = false;
+
+        for (let block of this.breakableBlocks) {
+            if (!block.active) continue;
+
+            // Bump animation
+            if (block.bumping) {
+                block.bumpTimer--;
+                if (block.bumpTimer <= 0) {
+                    block.bumping = false;
+                    needsRedraw = true;
+                }
+            }
+
+            let bRect = new Phaser.Geom.Rectangle(block.x, block.y, block.w, block.h);
+
+            // Check carrot hits
+            let carrots = this.carrots.getChildren();
+            for (let i = carrots.length - 1; i >= 0; i--) {
+                let c = carrots[i];
+                if (!c.active) continue;
+                if (bRect.contains(c.x, c.y)) {
+                    c.destroy();
+                    this.breakBlock(block);
+                    needsRedraw = true;
+                    break;
+                }
+            }
+
+            if (!block.active) continue;
+
+            // Check player jumping up into block from below
+            let p = this.player;
+            let pTop = p.y - SPRITE_SIZE;
+            if (p.body.velocity.y < -50 &&
+                p.x > block.x - 10 && p.x < block.x + block.w + 10 &&
+                pTop >= block.y - 8 && pTop <= block.y + block.h * 0.5) {
+                this.breakBlock(block);
+                needsRedraw = true;
+            }
+        }
+
+        if (needsRedraw) this.drawBreakableBlocks();
+    }
+
+    breakBlock(block) {
+        if (!block.active) return;
+        block.active = false;
+        this.spawnPoofParticles(block.x + block.w / 2, block.y + block.h / 2);
+        this.spawnBlockPowerup(block.x + block.w / 2, block.y, block.powerupType);
+    }
+
+    spawnBlockPowerup(x, y, type) {
+        let colorMap = {
+            spread_shot: 0xff8800, rapid_fire: 0xff2222,
+            big_carrot: 0x44ff44, shield: 0x4488ff, speed_boost: 0xffff00
+        };
+        let pickup = this.physics.add.sprite(x, y - 16, 'sprites', 'CARROT_SPRITE');
+        pickup.setScale(S * 0.9);
+        pickup.setDepth(7);
+        pickup.setTint(colorMap[type] || 0xffffff);
+        pickup.body.allowGravity = true;
+        pickup.body.setGravityY(200);
+        pickup.setBounce(0.3);
+        pickup._pickupType = 'powerup';
+        pickup._powerupType = type;
+        pickup._bobPhase = 0;
+        this.pickups.add(pickup);
+
+        this.time.delayedCall(15000, () => {
+            if (pickup && pickup.active) pickup.destroy();
+        });
     }
 
     spawnCelebrationParticles(x, y) {


### PR DESCRIPTION
Fixes #issue-18

- Crouching now allows movement (40% speed) and shooting; CTRL key alternative
- Pickups land on platforms/ground (gravity + colliders)
- Cave worm boss uses alpha instead of y-teleport off-screen
- Flying bosses Y-clamped to screen
- Goal post hidden until boss defeated
- Level complete text has stroke for readability
- Enemy AI more aggressive
- Bunny King + Ruin Knight get spiral shot attack
- Breakable ? blocks with 5 power-up types

Generated with [Claude Code](https://claude.ai/code)